### PR TITLE
trivial renaming of hello world indexing/retrieval embeddings app

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Here's a sample invocation of taking GloVe embeddings and creating a Lucene inde
 This is treating Lucene as a simple key-value store.
 
 ```
-$ target/appassembler/bin/IndexGloVe -index glove -input glove.840B.300d.txt
+$ target/appassembler/bin/IndexWordEmbeddings -index glove -input glove.840B.300d.txt
 ```
 
 Simple lookup example:
 
 ```
-$ target/appassembler/bin/LookupGloVe -index glove-float -word "happy"
+$ target/appassembler/bin/LookupWordEmbeddings -index glove -word "happy"
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -94,12 +94,12 @@
           <extraJvmArguments>-Xms512M -Xmx256G</extraJvmArguments>
           <programs>
             <program>
-              <mainClass>io.anserini.embeddings.IndexGloVe</mainClass>
-              <id>IndexGloVe</id>
+              <mainClass>io.anserini.embeddings.IndexWordEmbeddings</mainClass>
+              <id>IndexWordEmbeddings</id>
             </program>
             <program>
-              <mainClass>io.anserini.embeddings.LookupGloVe</mainClass>
-              <id>LookupGloVe</id>
+              <mainClass>io.anserini.embeddings.LookupWordEmbeddings</mainClass>
+              <id>LookupWordEmbeddings</id>
             </program>
           </programs>
         </configuration>

--- a/src/main/java/io/anserini/embeddings/IndexWordEmbeddings.java
+++ b/src/main/java/io/anserini/embeddings/IndexWordEmbeddings.java
@@ -46,10 +46,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Takes GloVe word embeddings and creates a Lucene index for lookup. This is treating Lucene as a simple key-value store.
+ * Takes word embeddings and creates a Lucene index for lookup. This is treating Lucene as a simple key-value store.
  */
-public class IndexGloVe {
-  private static final Logger LOG = LogManager.getLogger(IndexGloVe.class);
+public class IndexWordEmbeddings {
+  private static final Logger LOG = LogManager.getLogger(IndexWordEmbeddings.class);
 
   public static final class Args {
     @Option(name = "-input", metaVar = "[file]", required = true, usage = "GloVe data")
@@ -71,14 +71,14 @@ public class IndexGloVe {
     } catch (CmdLineException e) {
       System.err.println(e.getMessage());
       parser.printUsage(System.err);
-      System.err.println("Example: "+ IndexGloVe.class.getSimpleName() +
+      System.err.println("Example: "+ IndexWordEmbeddings.class.getSimpleName() +
           parser.printExample(OptionHandlerFilter.REQUIRED));
       return;
     }
 
     long startTime = System.currentTimeMillis();
     LOG.info("Loading GloVe vectors...");
-    WordVectors wordVectors = WordVectorSerializer.loadTxtVectors(indexArgs.input);
+    WordVectors wordVectors = WordVectorSerializer.loadStaticModel(indexArgs.input);
     LOG.info("Completed in " + (System.currentTimeMillis()-startTime)/1000 + "s elapsed.");
 
     final long start = System.nanoTime();
@@ -102,8 +102,8 @@ public class IndexGloVe {
       try {
         DataOutputStream dataOut = new DataOutputStream(bytesOut);
         dataOut.writeInt(vector.length);
-        for (int i = 0; i < vector.length; i++) {
-          dataOut.writeFloat((float) vector[i]);
+        for (double v : vector) {
+          dataOut.writeFloat((float) v);
         }
         dataOut.close();
       } catch (IOException e) {

--- a/src/main/java/io/anserini/embeddings/LookupWordEmbeddings.java
+++ b/src/main/java/io/anserini/embeddings/LookupWordEmbeddings.java
@@ -40,10 +40,10 @@ import java.util.List;
 
 /**
  * Example illustrating how to look up word vectors. Note that terms are processed with a Lucene Analyzer, which means
- * that a query term may match multiple entries in the original GloVe work embeddings. It's up to the client to figure
+ * that a query term may match multiple entries in the original word embeddings. It's up to the client to figure
  * out how to deal with this issue.
  */
-public class LookupGloVe {
+public class LookupWordEmbeddings {
   public static final class Args {
     @Option(name = "-word", metaVar = "[word]", required = true, usage = "word to look up")
     public String word;
@@ -61,7 +61,7 @@ public class LookupGloVe {
     } catch (CmdLineException e) {
       System.err.println(e.getMessage());
       parser.printUsage(System.err);
-      System.err.println("Example: "+ LookupGloVe.class.getSimpleName() +
+      System.err.println("Example: "+ LookupWordEmbeddings.class.getSimpleName() +
           parser.printExample(OptionHandlerFilter.REQUIRED));
       return;
     }
@@ -76,7 +76,7 @@ public class LookupGloVe {
       System.exit(-1);
     }
 
-    TermQuery query = new TermQuery(new Term(IndexGloVe.FIELD_WORD, qtokens.get(0)));
+    TermQuery query = new TermQuery(new Term(IndexWordEmbeddings.FIELD_WORD, qtokens.get(0)));
 
     TopDocs topDocs = searcher.search(query, Integer.MAX_VALUE);
     if (topDocs.totalHits == 0) {
@@ -87,8 +87,8 @@ public class LookupGloVe {
 
     for ( int i=0; i<topDocs.scoreDocs.length; i++ ) {
       Document doc = reader.document(topDocs.scoreDocs[i].doc);
-      List<String> tokens = AnalyzerUtils.tokenize(new SimpleAnalyzer(), doc.getField(IndexGloVe.FIELD_WORD).stringValue());
-      byte[] value = doc.getField(IndexGloVe.FIELD_VECTOR).binaryValue().bytes;
+      List<String> tokens = AnalyzerUtils.tokenize(new SimpleAnalyzer(), doc.getField(IndexWordEmbeddings.FIELD_WORD).stringValue());
+      byte[] value = doc.getField(IndexWordEmbeddings.FIELD_VECTOR).binaryValue().bytes;
       DataInputStream in = new DataInputStream(new ByteArrayInputStream(value));
 
       int cnt = in.readInt();
@@ -97,7 +97,7 @@ public class LookupGloVe {
         vector[n] = in.readFloat();
       }
 
-      System.out.println(String.format("%s %d [%f, %f, %f, %f ... ]", doc.getField(IndexGloVe.FIELD_WORD).stringValue(),
+      System.out.println(String.format("%s %d [%f, %f, %f, %f ... ]", doc.getField(IndexWordEmbeddings.FIELD_WORD).stringValue(),
           tokens.size(), vector[0], vector[1], vector[2], vector[3]));
     }
   }


### PR DESCRIPTION
hello world app names should reflect the fact that it is possible to use word embeddings from both GloVe and word2vec, hence renaming `IndexGloVe` to `IndexWordEmbeddings`.
(I've checked it works with GloVe and word2vec pretrained models, on Twitter and GoogleNews respectively).