### PR TITLE
FloatPoint nearest neighbour prototype for Anserini-embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,24 @@ Simple lookup example:
 ```
 $ target/appassembler/bin/LookupWordEmbeddings -index glove -word "happy"
 ```
+
+Nearest neighbour search
+========================
+
+Index dimensionality reduced word embeddings as Lucene `FloatPoints`. 
+Number of dimensions allowed is between 1 and 8.
+
+```
+$ target/appassembler/bin/IndexReducedWordEmbeddings -index glove -input glove.840B.300d.txt -dimensions 8
+```
+
+Simple nearest neighbour example:
+
+```
+$ target/appassembler/bin/NearestNeighbour -index glove -word "thomas"
+thomas
+vincent
+lewis
+fred
+williams
+```

--- a/pom.xml
+++ b/pom.xml
@@ -98,8 +98,16 @@
               <id>IndexWordEmbeddings</id>
             </program>
             <program>
+              <mainClass>io.anserini.embeddings.IndexReducedWordEmbeddings</mainClass>
+              <id>IndexReducedWordEmbeddings</id>
+            </program>
+            <program>
               <mainClass>io.anserini.embeddings.LookupWordEmbeddings</mainClass>
               <id>LookupWordEmbeddings</id>
+            </program>
+            <program>
+              <mainClass>io.anserini.embeddings.NearestNeighbour</mainClass>
+              <id>NearestNeighbour</id>
             </program>
           </programs>
         </configuration>
@@ -194,9 +202,19 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.25</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-sandbox</artifactId>
+      <version>7.5.0</version>
+    </dependency>
+    <dependency>
       <groupId>io.anserini</groupId>
       <artifactId>anserini</artifactId>
-      <version>0.2.0</version>
+      <version>0.2.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.deeplearning4j</groupId>

--- a/src/main/java/io/anserini/embeddings/IndexReducedWordEmbeddings.java
+++ b/src/main/java/io/anserini/embeddings/IndexReducedWordEmbeddings.java
@@ -1,0 +1,156 @@
+/**
+ * Anserini: A toolkit for reproducible information retrieval research built on Lucene
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.embeddings;
+
+import org.apache.commons.lang3.time.DurationFormatUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.document.*;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+import org.deeplearning4j.models.embeddings.loader.WordVectorSerializer;
+import org.deeplearning4j.models.word2vec.Word2Vec;
+import org.kohsuke.args4j.*;
+import org.nd4j.linalg.api.ndarray.INDArray;
+import org.nd4j.linalg.dimensionalityreduction.PCA;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Takes word embeddings and creates a Lucene index for lookup and nearest neighbour search.
+ * Embeddings dimensionality is reduced using PCA to allow indexing them as {@link FloatPoint}s.
+ */
+public class IndexReducedWordEmbeddings {
+  private static final Logger LOG = LogManager.getLogger(IndexReducedWordEmbeddings.class);
+
+  public static final class Args {
+    @Option(name = "-input", metaVar = "[file]", required = true, usage = "GloVe data")
+    public File input;
+
+    @Option(name = "-index", metaVar = "[path]", required = true, usage = "index path")
+    public Path index;
+
+    @Option(name = "-dimensions", metaVar = "[int]", required = false, usage = "dimensions")
+    public int dimensions;
+  }
+
+  public static final String FIELD_WORD = "word";
+  public static final String FIELD_REDUCED_VECTOR = "reduced_vector";
+  public static final String FIELD_POINT = "point";
+
+  public static void main(String[] args) throws Exception {
+    Args indexArgs = new Args();
+    CmdLineParser parser = new CmdLineParser(indexArgs, ParserProperties.defaults().withUsageWidth(90));
+
+    try {
+      parser.parseArgument(args);
+    } catch (CmdLineException e) {
+      System.err.println(e.getMessage());
+      parser.printUsage(System.err);
+      System.err.println("Example: "+ IndexReducedWordEmbeddings.class.getSimpleName() +
+          parser.printExample(OptionHandlerFilter.REQUIRED));
+      return;
+    }
+
+    long startTime = System.currentTimeMillis();
+    LOG.info("Loading vectors...");
+    Word2Vec wordVectors = WordVectorSerializer.readWord2VecModel(indexArgs.input);
+    LOG.info("Completed in " + (System.currentTimeMillis()-startTime)/1000 + "s elapsed.");
+
+    final long start = System.nanoTime();
+    LOG.info("Starting indexer...");
+
+    final int dimensions = indexArgs.dimensions;
+    final Directory dir = FSDirectory.open(indexArgs.index);
+    final Analyzer analyzer = new EnglishStemmingAnalyzer("porter"); // Default used in indexing.
+    final IndexWriterConfig config = new IndexWriterConfig(analyzer);
+    config.setOpenMode(IndexWriterConfig.OpenMode.CREATE);
+
+    final IndexWriter writer = new IndexWriter(dir, config);
+    final AtomicInteger cnt = new AtomicInteger();
+
+    LOG.info("Reducing vectors...");
+
+    startTime = System.currentTimeMillis();
+    INDArray weights = wordVectors.lookupTable().getWeights();
+    INDArray reduced = PCA.pca(weights, dimensions, true);
+
+    LOG.info("Completed in " + (System.currentTimeMillis()-startTime)/1000 + "s elapsed.");
+
+    for (int i = 0; i < reduced.rows(); i++) {
+      Document doc = new Document();
+
+      String word = wordVectors.vocab().wordAtIndex(i);
+
+      doc.add(new TextField(FIELD_WORD, word, Field.Store.YES));
+      doc.add(new FloatPoint(FIELD_POINT, reduced.getRow(i).toFloatVector()));
+
+      ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
+      try {
+        DataOutputStream dataOut = new DataOutputStream(bytesOut);
+        double[] vector = reduced.getRow(i).toDoubleVector();
+        dataOut.writeInt(vector.length);
+        for (double v : vector) {
+          dataOut.writeFloat((float) v);
+        }
+        dataOut.close();
+      } catch (IOException e) {
+        LOG.error(e);
+      }
+
+      doc.add(new StoredField(FIELD_REDUCED_VECTOR, bytesOut.toByteArray()));
+      i++;
+      try {
+        writer.addDocument(doc);
+        int cur = cnt.incrementAndGet();
+        if (cur % 100000 == 0) {
+          LOG.info(cnt + " words added.");
+        }
+      } catch (IOException e) {
+        LOG.error(e);
+      }
+
+    }
+
+    LOG.info(cnt.get() + " words added.");
+    int numIndexed = writer.maxDoc();
+
+    try {
+      writer.commit();
+    } finally {
+      try {
+        writer.close();
+      } catch (IOException e) {
+        LOG.error(e);
+      }
+    }
+
+    long duration = TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+    LOG.info("Total " + numIndexed + " reduced words indexed in " +
+        DurationFormatUtils.formatDuration(duration, "HH:mm:ss"));
+  }
+
+}

--- a/src/main/java/io/anserini/embeddings/NearestNeighbour.java
+++ b/src/main/java/io/anserini/embeddings/NearestNeighbour.java
@@ -1,0 +1,98 @@
+/**
+ * Anserini: A toolkit for reproducible information retrieval research built on Lucene
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.anserini.embeddings;
+
+import io.anserini.util.AnalyzerUtils;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.FloatPointNearestNeighbor;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.*;
+import org.apache.lucene.store.FSDirectory;
+import org.kohsuke.args4j.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Example illustrating how to perform word vectors nearest neighbour using Lucene {@link FloatPointNearestNeighbor}.
+ */
+public class NearestNeighbour {
+  public static final class Args {
+    @Option(name = "-word", metaVar = "[word]", required = true, usage = "word to look up")
+    public String word;
+
+    @Option(name = "-index", metaVar = "[path]", required = true, usage = "index path")
+    public Path index;
+  }
+
+  public static void main(String[] args) throws Exception {
+    Args lookupArgs = new Args();
+    CmdLineParser parser = new CmdLineParser(lookupArgs, ParserProperties.defaults().withUsageWidth(90));
+
+    try {
+      parser.parseArgument(args);
+    } catch (CmdLineException e) {
+      System.err.println(e.getMessage());
+      parser.printUsage(System.err);
+      System.err.println("Example: "+ NearestNeighbour.class.getSimpleName() +
+          parser.printExample(OptionHandlerFilter.REQUIRED));
+      return;
+    }
+
+    IndexReader reader = DirectoryReader.open(FSDirectory.open(lookupArgs.index));
+    IndexSearcher searcher = new IndexSearcher(reader);
+
+    Analyzer analyzer = new EnglishStemmingAnalyzer("porter"); // Default used in indexing.
+    List<String> qtokens = AnalyzerUtils.tokenize(analyzer, lookupArgs.word);
+    if (qtokens.size() != 1) {
+      System.err.println("Error: word tokenizes to more than one token");
+      System.exit(-1);
+    }
+
+    TermQuery query = new TermQuery(new Term(IndexWordEmbeddings.FIELD_WORD, qtokens.get(0)));
+
+    TopDocs topDocs = searcher.search(query, 1);
+    if (topDocs.totalHits == 0) {
+      System.err.println("Error: term not found!");
+      System.exit(-1);
+    }
+
+
+    for ( int i=0; i<topDocs.scoreDocs.length; i++ ) {
+      Document doc = reader.document(topDocs.scoreDocs[i].doc);
+      byte[] value = doc.getField(IndexReducedWordEmbeddings.FIELD_REDUCED_VECTOR).binaryValue().bytes;
+      DataInputStream in = new DataInputStream(new ByteArrayInputStream(value));
+
+      int cnt = in.readInt();
+      float[] vector = new float[cnt];
+      for (int n=0; n<vector.length; n++) {
+        vector[n] = in.readFloat();
+      }
+
+      TopFieldDocs nearest = FloatPointNearestNeighbor.nearest(searcher, IndexReducedWordEmbeddings.FIELD_POINT, 5, vector);
+      for (ScoreDoc sd : nearest.scoreDocs) {
+        Document document = reader.document(sd.doc);
+        System.out.println(String.format("%s", document.getField(IndexWordEmbeddings.FIELD_WORD).stringValue()));
+      }
+    }
+  }
+}


### PR DESCRIPTION
This prototype allows indexing PCA reduced word embeddings in Lucene as ´FloatPoints´ and perform nearest neighbour search.
It works only on top of branch `lucene7` of Anserini (see Anserini dependency set to 0.2.1-SNAPSHOT).